### PR TITLE
[Feature/user］토큰 갱신 & 로그아웃 API 작성

### DIFF
--- a/apps/accounts/authentication.py
+++ b/apps/accounts/authentication.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from django.conf import settings
+from rest_framework.request import Request
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+
+class CookieOrHeaderJWTAuthentication(JWTAuthentication):
+    """
+    - Authorization 헤더가 있으면 헤더 인증
+    - 없으면 HttpOnly 쿠키의 access 토큰으로 인증
+    """
+
+    def authenticate(self, request: Request) -> Any:
+        header = self.get_header(request)
+        if header is not None:
+            return super().authenticate(request)
+
+        cookie_name = getattr(settings, "AUTH_ACCESS_COOKIE_NAME", "access")
+        raw_token: Optional[str] = request.COOKIES.get(cookie_name)
+        if not raw_token:
+            return None
+
+        validated_token = self.get_validated_token(raw_token)
+        user = self.get_user(validated_token)
+        return (user, validated_token)

--- a/apps/accounts/serializers/auth_serializers.py
+++ b/apps/accounts/serializers/auth_serializers.py
@@ -7,6 +7,12 @@ from rest_framework import serializers
 from apps.accounts.models.users import User
 
 
+class TokenPayloadSerializer(serializers.Serializer[Any]):
+    access_token = serializers.CharField()
+    token_type = serializers.CharField(default="Bearer")
+    expires_in = serializers.IntegerField()
+
+
 class LoginRequestSerializer(serializers.Serializer[Any]):
     email = serializers.EmailField()
     password = serializers.CharField(trim_whitespace=False)
@@ -14,12 +20,7 @@ class LoginRequestSerializer(serializers.Serializer[Any]):
 
 
 class LoginResponseSerializer(serializers.Serializer[Any]):
-    # token
-    access_token = serializers.CharField()
-    token_type = serializers.CharField(default="Bearer")
-    expires_in = serializers.IntegerField()
-
-    # user
+    token = TokenPayloadSerializer()
     user = serializers.SerializerMethodField()
 
     def get_user(self, obj: dict[str, Any]) -> dict[str, Any]:

--- a/apps/accounts/urls/auth_urls.py
+++ b/apps/accounts/urls/auth_urls.py
@@ -1,7 +1,9 @@
 from django.urls import URLPattern, URLResolver, path
 
-from apps.accounts.views.auth_views import LoginView
+from apps.accounts.views.auth_views import LoginView, LogoutAPIView, TokenRefreshAPIView
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("auth/login", LoginView.as_view(), name="email_login"),
+    path("auth/login", LoginView.as_view(), name="auth_login"),
+    path("auth/refresh", TokenRefreshAPIView.as_view(), name="auth_refresh"),
+    path("auth/logout", LogoutAPIView.as_view(), name="auth_logout"),
 ]

--- a/apps/accounts/utils/cookies.py
+++ b/apps/accounts/utils/cookies.py
@@ -5,31 +5,66 @@ from typing import Literal, Optional, cast
 from django.conf import settings
 from rest_framework.response import Response
 
+CookieType = Literal["access", "refresh"]
 SameSite = Optional[Literal["Lax", "Strict", "None", False]]
 
 
-def _cookie_samesite() -> SameSite:
-    value = getattr(settings, "AUTH_REFRESH_COOKIE_SAMESITE", None)
-    if value in ("Lax", "Strict", "None"):
+def _cookie_samesite(type: CookieType) -> SameSite:
+    # access/refresh 각각의 samesite 설정을 읽도록 분리
+    attr = (
+        "AUTH_ACCESS_COOKIE_SAMESITE"
+        if type == "access"
+        else "AUTH_REFRESH_COOKIE_SAMESITE"
+    )
+    value = getattr(settings, attr, None)
+    if value in ("Lax", "Strict", "None", False):
         return cast(SameSite, value)
     return None
 
 
-def set_refresh_cookie(response: Response, refresh: str, *, max_age: int) -> None:
+def _cookie_attr(type: CookieType, suffix: str) -> str:
+    # settings 속성명 생성
+    prefix = "AUTH_ACCESS_COOKIE_" if type == "access" else "AUTH_REFRESH_COOKIE_"
+    return f"{prefix}{suffix}"
+
+
+def _get(type: CookieType, suffix: str) -> object:
+    return getattr(settings, _cookie_attr(type, suffix))
+
+
+def _set_cookie(
+    response: Response, *, type: CookieType, token: str, max_age: int
+) -> None:
     response.set_cookie(
-        key=settings.AUTH_REFRESH_COOKIE_NAME,
-        value=refresh,
+        key=cast(str, _get(type, "NAME")),
+        value=token,
         max_age=max_age,
-        path=settings.AUTH_REFRESH_COOKIE_PATH,
-        secure=settings.AUTH_REFRESH_COOKIE_SECURE,
-        httponly=settings.AUTH_REFRESH_COOKIE_HTTPONLY,
-        samesite=_cookie_samesite(),
+        path=cast(str, _get(type, "PATH")),
+        secure=cast(bool, _get(type, "SECURE")),
+        httponly=cast(bool, _get(type, "HTTPONLY")),
+        samesite=_cookie_samesite(type),
     )
+
+
+def _clear_cookie(response: Response, *, type: CookieType) -> None:
+    response.delete_cookie(
+        key=cast(str, _get(type, "NAME")),
+        path=cast(str, _get(type, "PATH")),
+        samesite=_cookie_samesite(type),
+    )
+
+
+def set_access_cookie(response: Response, access: str, *, max_age: int) -> None:
+    _set_cookie(response, type="access", token=access, max_age=max_age)
+
+
+def clear_access_cookie(response: Response) -> None:
+    _clear_cookie(response, type="access")
+
+
+def set_refresh_cookie(response: Response, refresh: str, *, max_age: int) -> None:
+    _set_cookie(response, type="refresh", token=refresh, max_age=max_age)
 
 
 def clear_refresh_cookie(response: Response) -> None:
-    response.delete_cookie(
-        key=settings.AUTH_REFRESH_COOKIE_NAME,
-        path=settings.AUTH_REFRESH_COOKIE_PATH,
-        samesite=_cookie_samesite(),
-    )
+    _clear_cookie(response, type="refresh")

--- a/apps/accounts/views/auth_views.py
+++ b/apps/accounts/views/auth_views.py
@@ -25,7 +25,12 @@ from apps.accounts.services.login_throttle import (
     clear_login_failures,
     record_login_failure,
 )
-from apps.accounts.utils.cookies import clear_refresh_cookie, set_refresh_cookie
+from apps.accounts.utils.cookies import (
+    clear_access_cookie,
+    clear_refresh_cookie,
+    set_access_cookie,
+    set_refresh_cookie,
+)
 from apps.core.enumeration.account_user_enumeration import UserStatus
 
 ACCESS_LIFETIME = timedelta(seconds=settings.JWT_ACCESS_TOKEN_LIFETIME)
@@ -138,6 +143,7 @@ class LoginView(APIView):
             status=status.HTTP_200_OK,
         )
         set_refresh_cookie(response, refresh, max_age=refresh_max_age)
+        set_access_cookie(response, access, max_age=expires_in)
         return response
 
 
@@ -178,7 +184,9 @@ class TokenRefreshAPIView(APIView):
                 "expires_in": expires_in,
             }
         )
-        return Response(out.data, status=status.HTTP_200_OK)
+        resp = Response(out.data, status=status.HTTP_200_OK)
+        set_access_cookie(resp, access, max_age=expires_in)
+        return resp
 
 
 class LogoutAPIView(APIView):
@@ -205,12 +213,15 @@ class LogoutAPIView(APIView):
         )
 
         # 응답은 항상 쿠키 삭제
-        resp = Response({"detail": "로그아웃되었습니다."}, status=status.HTTP_200_OK)
-        clear_refresh_cookie(resp)
+        response = Response(
+            {"detail": "로그아웃되었습니다."}, status=status.HTTP_200_OK
+        )
+        clear_refresh_cookie(response)
+        clear_access_cookie(response)
 
         # refresh 없으면 “이미 로그아웃”으로 성공 처리
         if not refresh_raw:
-            return resp
+            return response
 
         # blacklist 가능하면 시도 (token_blacklist 앱이 켜져있어야 정상 동작)
         try:
@@ -218,6 +229,6 @@ class LogoutAPIView(APIView):
             token.blacklist()
         except Exception:
             # 만료/위조/이미 블랙리스트 등은 그냥 성공 처리
-            return resp
+            return response
 
-        return resp
+        return response

--- a/apps/accounts/views/auth_views.py
+++ b/apps/accounts/views/auth_views.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
-from typing import Any
+from datetime import timedelta
+from typing import Any, Optional, cast
 
+from django.conf import settings
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import RefreshToken
 
 from apps.accounts.serializers.auth_serializers import (
     LoginRequestSerializer,
     LoginResponseSerializer,
+    TokenPayloadSerializer,
 )
 from apps.accounts.services.auth_services import authenticate_user, issue_tokens
 from apps.accounts.services.login_throttle import (
@@ -20,8 +25,11 @@ from apps.accounts.services.login_throttle import (
     clear_login_failures,
     record_login_failure,
 )
-from apps.accounts.utils.cookies import set_refresh_cookie
+from apps.accounts.utils.cookies import clear_refresh_cookie, set_refresh_cookie
 from apps.core.enumeration.account_user_enumeration import UserStatus
+
+ACCESS_LIFETIME = timedelta(seconds=settings.JWT_ACCESS_TOKEN_LIFETIME)
+expires_in = int(ACCESS_LIFETIME.total_seconds())
 
 
 class LoginView(APIView):
@@ -116,9 +124,11 @@ class LoginView(APIView):
 
         out = LoginResponseSerializer(
             {
-                "access_token": access,
-                "token_type": "Bearer",
-                "expires_in": 3600,
+                "token": {
+                    "access_token": access,
+                    "token_type": "Bearer",
+                    "expires_in": expires_in,
+                },
                 "user": user,
             }
         )
@@ -129,3 +139,85 @@ class LoginView(APIView):
         )
         set_refresh_cookie(response, refresh, max_age=refresh_max_age)
         return response
+
+
+class TokenRefreshAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        tags=["유저"],
+        operation_id="auth_token_refresh",
+        summary="토큰 갱신",
+        description="HttpOnly 쿠키의 Refresh Token으로 Access Token을 재발급합니다.",
+        request=None,
+        responses={200: TokenPayloadSerializer},
+    )
+    def post(self, request: Request) -> Response:
+        refresh_raw: Optional[str] = request.COOKIES.get(
+            settings.AUTH_REFRESH_COOKIE_NAME
+        )
+        if not refresh_raw:
+            return Response(
+                {"detail": "리프레시 토큰이 필요합니다."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        try:
+            refresh = RefreshToken(cast(Any, refresh_raw))
+            access = str(refresh.access_token)
+        except TokenError:
+            return Response(
+                {"detail": "유효하지 않은 리프레시 토큰입니다."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        out = TokenPayloadSerializer(
+            instance={
+                "access_token": access,
+                "token_type": "Bearer",
+                "expires_in": expires_in,
+            }
+        )
+        return Response(out.data, status=status.HTTP_200_OK)
+
+
+class LogoutAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["유저"],
+        operation_id="auth_logout",
+        summary="로그아웃",
+        description="Refresh Token을 무효화(blacklist)하고 쿠키를 삭제합니다.",
+        request=None,
+        responses={
+            200: {
+                "type": "object",
+                "properties": {
+                    "message": {"type": "string", "example": "로그아웃되었습니다."}
+                },
+            }
+        },
+    )
+    def post(self, request: Request) -> Response:
+        refresh_raw: Optional[str] = request.COOKIES.get(
+            settings.AUTH_REFRESH_COOKIE_NAME
+        )
+
+        # 응답은 항상 쿠키 삭제
+        resp = Response({"detail": "로그아웃되었습니다."}, status=status.HTTP_200_OK)
+        clear_refresh_cookie(resp)
+
+        # refresh 없으면 “이미 로그아웃”으로 성공 처리
+        if not refresh_raw:
+            return resp
+
+        # blacklist 가능하면 시도 (token_blacklist 앱이 켜져있어야 정상 동작)
+        try:
+            token = RefreshToken(cast(Any, refresh_raw))
+            token.blacklist()
+        except Exception:
+            # 만료/위조/이미 블랙리스트 등은 그냥 성공 처리
+            return resp
+
+        return resp

--- a/apps/core/enumeration/account_user_enumeration.py
+++ b/apps/core/enumeration/account_user_enumeration.py
@@ -7,10 +7,10 @@ class GenderChoices(models.TextChoices):
 
 
 class UserStatus(models.TextChoices):
-    ACTIVE = ("ACTIVE",)
-    DEACTIVATED = "DEACTIVATED"
-    BANNED = "BANNED"
-    DORMANT = "DORMANT"
+    ACTIVE = "ACTIVE", "ACTIVE"
+    DEACTIVATED = "DEACTIVATED", "DEACTIVATED"
+    BANNED = "BANNED", "BANNED"
+    DORMANT = "DORMANT", "DORMANT"
 
 
 class UserRoleChoices(models.TextChoices):

--- a/config/settings.py
+++ b/config/settings.py
@@ -132,7 +132,7 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ),
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "apps.accounts.authentication.CookieOrHeaderJWTAuthentication",
     ),
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
 }
@@ -162,6 +162,13 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(hours=24),
     "AUTH_HEADER_TYPES": ("Bearer",),
 }
+
+# access 쿠키 옵션
+AUTH_ACCESS_COOKIE_NAME = "access"
+AUTH_ACCESS_COOKIE_PATH = "/"
+AUTH_ACCESS_COOKIE_SECURE = not DEBUG
+AUTH_ACCESS_COOKIE_HTTPONLY = True
+AUTH_ACCESS_COOKIE_SAMESITE = "Lax"
 
 # refresh 쿠키 옵션
 AUTH_REFRESH_COOKIE_NAME = "refresh"


### PR DESCRIPTION
## 🔎개요 
- 토큰 갱신 & 로그아웃 API 작성
 
<br/>
 
## 📝작업 내용
- [x] 토큰 갱신 & 로그아웃 API 작성
- [x] access token도 HttpOnly 쿠키로 관리하도록 수정

### 토큰 갱신 API 
<img width="2121" height="296" alt="image" src="https://github.com/user-attachments/assets/27937970-3ded-4722-be66-8b6cb0bab618" />

### 로그아웃 API
<img width="2110" height="176" alt="image" src="https://github.com/user-attachments/assets/80ed9f37-e791-4745-894c-ad2d38a82baa" />

<br/>

게시글 등록 API 사용해서 로그인/로그아웃 상태 잘 적용되는 것도 확인했습니다.

<br/>
 
## 👀변경 사항
- [x] 스웨거 사용시 로그인/로그아웃 API 실행만으로 인증 상태 관리가 가능합니다. (Bearer Token 붙여넣을 필요 없음)

 
<br/>
 
 
## #️⃣관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
