### PR TITLE
[Feature/community/comments] 댓글&신고 관련 API 수정

### DIFF
--- a/apps/community/urls/comment_urls.py
+++ b/apps/community/urls/comment_urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
         name="comment_delete",
     ),
     path(
-        "posts/<int:post_id>/comments",
+        "posts/<int:post_id>/comments/list",
         CommentListAPIView.as_view(),
         name="comments_list",
     ),

--- a/apps/community/views/comment_report_views.py
+++ b/apps/community/views/comment_report_views.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+from django.db import IntegrityError
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -109,12 +110,20 @@ class CommentReportCreateAPIView(APIView):
         user = cast(User, request.user)
 
         # 댓글 신고 생성
-        report = create_comment_report(
-            post_id=post_id,
-            comment_id=comment_id,
-            reporter=user,
-            reason=serializer.validated_data["reason"],
-        )
+        try:
+            report = create_comment_report(
+                post_id=post_id,
+                comment_id=comment_id,
+                reporter=user,
+                reason=serializer.validated_data["reason"],
+            )
+        except IntegrityError as e:
+            if "unique_comment_reports_comment_reporter" in str(e):
+                return Response(
+                    {"detail": "이미 해당 댓글을 신고했습니다."},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            raise
 
         return Response(
             CommentReportResponseSerializer.from_instance(report),

--- a/apps/community/views/post_report_views.py
+++ b/apps/community/views/post_report_views.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+from django.db import IntegrityError
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -109,11 +110,19 @@ class PostReportCreateAPIView(APIView):
         user = cast(User, request.user)
 
         # 게시글 신고 생성
-        report = create_post_report(
-            post_id=post_id,
-            reporter=user,
-            reason=serializer.validated_data["reason"],
-        )
+        try:
+            report = create_post_report(
+                post_id=post_id,
+                reporter=user,
+                reason=serializer.validated_data["reason"],
+            )
+        except IntegrityError as e:
+            if "unique_post_reports_post_reporter" in str(e):
+                return Response(
+                    {"detail": "이미 해당 게시글을 신고했습니다."},
+                    status=status.HTTP_409_CONFLICT,
+                )
+            raise
 
         return Response(
             PostReportResponseSerializer.from_instance(report),


### PR DESCRIPTION
## 🔎개요 
- 댓글&신고 관련 API 수정
 
<br/>
 
## 📝작업 내용
- [x] 댓글 목록 조회 API 엔드포인트 분리 -> /api/v1/posts/{post_id}/comments/list
- [x] 댓글 및 게시글 중복 신고 시 409 에러 처리 되도록 수정
 
<br/>
 ### 댓글 목록 조회 API 정상 작동 확인
<img width="1114" height="273" alt="image" src="https://github.com/user-attachments/assets/a9f2c2be-3d05-4890-97df-4e9f3d711b6a" />

### 중복 신고 처리 
<img width="1120" height="229" alt="image" src="https://github.com/user-attachments/assets/e3a3f575-c9d4-49f9-9f6d-fc5a20fc42dd" />
<img width="1122" height="223" alt="image" src="https://github.com/user-attachments/assets/4f51ec0a-bf74-47ba-9223-a94cdbeb6a85" />

