### PR TITLE
[ Fix / minsoo] 비로그인 채팅창 목록 조회 허용 / 퇴장 후 재입장 500에러 Fix

### DIFF
--- a/apps/chat/migrations/0004_alter_membership_unique_active.py
+++ b/apps/chat/migrations/0004_alter_membership_unique_active.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0003_remove_room_chat_room_updated_5097bc_idx_and_more"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="membership",
+            name="unique_membership",
+        ),
+        migrations.AddConstraint(
+            model_name="membership",
+            constraint=models.UniqueConstraint(
+                fields=("room", "user"),
+                condition=models.Q(left_at__isnull=True),
+                name="unique_active_membership",
+            ),
+        ),
+    ]

--- a/apps/chat/models/membership.py
+++ b/apps/chat/models/membership.py
@@ -18,7 +18,12 @@ class Membership(models.Model):
     class Meta:
         db_table = "chat_membership"
         constraints = [
-            models.UniqueConstraint(fields=["room", "user"], name="unique_membership")
+            # 같은 방에서 동시에 한 건의 활성 멤버십만 허용
+            models.UniqueConstraint(
+                fields=["room", "user"],
+                condition=models.Q(left_at__isnull=True),
+                name="unique_active_membership",
+            )
         ]
         indexes = [
             models.Index(fields=["user", "joined_at"], name="idx_chat_user_joined_at"),

--- a/apps/chat/services/membership_service.py
+++ b/apps/chat/services/membership_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.db.models import F, Q
 from django.utils import timezone
 
@@ -60,12 +60,21 @@ def join_room(*, user: User, room: Room) -> Membership:
             raise PermissionError("이미 다른 채팅방에 접속 중입니다.")
         return active
 
-    membership = Membership.objects.create(
-        user=user,
-        room=room,
-        joined_at=_now(),
-        left_at=None,
-    )
+    try:
+        membership = Membership.objects.create(
+            user=user,
+            room=room,
+            joined_at=_now(),
+            left_at=None,
+        )
+    except IntegrityError:
+        # 동시 요청 등으로 인한 중복 멤버십 생성 시도 시, 기존 활성 멤버십 반환
+        existing = Membership.objects.filter(
+            user=user, room=room, left_at__isnull=True
+        ).first()
+        if existing:
+            return existing
+        raise
 
     # 동시성 고려해서 F() 업데이트
     Room.objects.filter(id=room.id).update(participant_count=F("participant_count") + 1)

--- a/apps/chat/views/room_view.py
+++ b/apps/chat/views/room_view.py
@@ -3,6 +3,7 @@
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -16,6 +17,8 @@ from apps.chat.serializers.room_serializer import (
 
 
 class RoomListAPIView(APIView):
+    permission_classes = [AllowAny]
+
     @extend_schema(summary="채팅방 목록 조회", tags=["채팅"])
     def get(self, request: Request) -> Response:
         rooms = get_rooms()
@@ -25,6 +28,8 @@ class RoomListAPIView(APIView):
 
 
 class RoomDetailAPIView(APIView):
+    permission_classes = [AllowAny]
+
     @extend_schema(summary="채팅방 디테일", tags=["채팅"])
     def get(self, request: Request, room_id: int) -> Response:
         room = get_object_or_404(Room, pk=room_id)

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 


### PR DESCRIPTION
## 🔎개요 
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
- 관련 이슈 번호: #123
- 작업 요약: 
  1. 비로그인 채팅방 조회 허용 - RoomListAPIView, RoomDetailAPIView에 AllowAny 권한 추가                                                                             
  2. 재입장 가능하도록 UniqueConstraint 수정 - (room, user) → (room, user) WHERE left_at IS NULL 조건부 제약으로 변경                                                
  3. 재입장 시 IntegrityError 처리 - 동시 요청/race condition 발생 시 기존 활성 멤버십 반환                                                                          
  4. 퇴장 후 재입장 500 에러 해결 - 이전 멤버십 레코드가 있어도 새 입장 가능  
 
<br/>
 
## 📝작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- [ ] 작업 내용 1
- [ ] 작업 내용 2
- [ ] 작업 내용 3
 
<br/>
 
## 👀변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
- [ ] 주요 변경 사항 1
- [ ] 주요 변경 사항 2
- [ ] 주요 변경 사항 3

 
<br/>
 
 
## #️⃣관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
